### PR TITLE
Require LTS node and npm versions

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,3 @@
 # Force npm to run node-gyp also as root, preventing permission denied errors in AWS with npm@5
 unsafe-perm=true
+engine-strict=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ dist: trusty
 language: node_js
 service_name: travis-pro
 node_js:
-  - "9"
+  - "8"
 
 cache:
   directories:

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     ]
   },
   "engines": {
-    "node": ">= 8.0"
+    "node": ">= 8.11 <9",
+    "npm": ">= 5.6 <5.7"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",


### PR DESCRIPTION
pinning to avoid issues with differences in dev enviroment. this basically forces the user to have those versions of node and npm on his system.

@fedealconada  encountered errors because he had node 10.5 and I had node 9.7 at dev time.


He downgraded to node 8.11.3 (LTS) but because his NPM was still 6.10 it was still causing problems.

The nodejs website itself recommends LTS for most users.
https://nodejs.org/en/


