### PR TITLE
fix ganache-cli bug (not being properly killed)

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "private": false,
   "main": "dist/index.js",
   "scripts": {
-    "test": "node_modules/jest/bin/jest.js __tests__/*.test.ts __tests__/integration/*.test.ts",
+    "test": "node_modules/jest/bin/jest.js __tests__/*.test.ts && node_modules/jest/bin/jest.js __tests__/integration/*.test.ts --runInBand",
     "start": "./node_modules/.bin/ts-node server.ts",
     "build": "rm -rf dist && ./node_modules/.bin/tsc -p ./tsconfig.json",
     "serve": "node dist/server.js",


### PR DESCRIPTION
- it seems that when running on Travis, ganacheChildProcess PID differs
from the PID gotten by doing `pgrep -f ganache-cli`
- fix consists on killing the last PID