### PR TITLE
disable

### DIFF
--- a/src/database/config.ts
+++ b/src/database/config.ts
@@ -29,7 +29,7 @@ const Config = {
     database: 'qiibee',
     host: 'localhost',
     connectionLimit: 3,
-    debug: true
+    debug: false
   }
 }
 


### PR DESCRIPTION
disabling database sequelize logs. they have never been useful for me so far and they are very large, making it very hard to read build logs in travis.