### PR TITLE
HOTFIX: remove integer validation until better understood

### DIFF
--- a/src/transactions/controller.ts
+++ b/src/transactions/controller.ts
@@ -167,7 +167,7 @@ const buildRawTransactionSchema = Joi.object().keys({
     from: validation.ethereumAddress().required(),
     to: validation.ethereumAddress().required(),
     contractAddress: validation.ethereumAddress().required(),
-    transferAmount: Joi.number().integer().greater(0).required()
+    transferAmount: Joi.required()
   })
 })
 const buildRawTransaction = async (req, res) => {


### PR DESCRIPTION
currently causes validation failure for valid tx amount 119489999999999994884