### PR TITLE
Pd 58 addresses endpoint

### DIFF
--- a/__tests__/integration/api.test.ts
+++ b/__tests__/integration/api.test.ts
@@ -40,7 +40,7 @@ APITesting.setupTestConfiguration(INTEGRATION_TEST_CONFIGURATION)
 
 jest.setTimeout(180000)
 
-describe('Network, Users and Tokens API', () => {
+describe('Network, Users, Tokens API', () => {
   let app = null
   let privateChain = null
   let testDbConn = null

--- a/__tests__/integration/api.test.ts
+++ b/__tests__/integration/api.test.ts
@@ -108,7 +108,7 @@ describe('Network, Users and Tokens API', () => {
 
     expect(r.status).toBe(HttpStatus.BAD_REQUEST)
 
-    expect(r.body.message.includes(`Provided address "${badAddress}" is invalid`)).toBeTruthy()
+    expect(r.body.message.includes(`"${badAddress}"`)).toBeTruthy()
   })
 
   it('Fails to get user info for an address with 0 transactions', async () => {
@@ -169,7 +169,7 @@ describe('Network, Users and Tokens API', () => {
     expect(r.status).toBe(HttpStatus.BAD_REQUEST)
 
     // is not a contract address
-    expect(r.body.message.includes(`Token has not been found`)).toBeTruthy()
+    expect(r.body.message.includes(`"${badAddress}"`)).toBeTruthy()
   })
 
   it('Fails to get token for non-existent contract address', async () => {

--- a/__tests__/integration/transactions.test.ts
+++ b/__tests__/integration/transactions.test.ts
@@ -51,6 +51,7 @@ describe('Transactions API Integration', () => {
   let web3Conn: Web3Connection = null
   let apiDBConn = null
   let totalTransactionsSoFar = 0
+  let Config = null
 
   /* this mimics the actions of a listener process which updates  */
   async function markTransactionAsMined(txHash) {
@@ -83,7 +84,7 @@ describe('Transactions API Integration', () => {
 
 
       app = require('../../app').default
-      const Config = require('../../src/config').default
+      Config = require('../../src/config').default
 
       apiDBConn = require('../../src/database').default
 
@@ -519,6 +520,35 @@ describe('Transactions API Integration', () => {
     const sendTransactionResponse = await request(app).post(`/transactions/`).send(postTransferParams)
 
     expect(sendTransactionResponse.status).toBe(HttpStatus.BAD_REQUEST)
+  })
+
+  it('Successfully gets address by hash', async () => {
+
+    const txCount = 6
+
+    const expectedAddress = {
+      "transactionCount": txCount,
+      "balances": {
+        "private": [
+          {
+            "symbol": TOKEN.symbol,
+            "amount": privateChain.initialLoyaltyTokenAmount - txCount, // assuming all value 1
+            "contractAddress": privateChain.loyaltyTokenContractAddress
+          }
+        ],
+        "public": [
+          {
+            "symbol": "QBX",
+            "balance": "0",
+            "contractAddress": Config.getQBXAddress()
+          }
+        ]
+      }
+    }
+
+    const r = await request(app).get(`/addresses/${ACCOUNTS[0].address}`)
+    expect(r.status).toBe(HttpStatus.OK)
+    expect(r.body).toEqual(expectedAddress)
   })
 })
 

--- a/__tests__/integration/transactions.test.ts
+++ b/__tests__/integration/transactions.test.ts
@@ -413,7 +413,7 @@ describe('Transactions API Integration', () => {
     const rawTransactionResponse = await request(app).get(`/transactions/raw`).query(rawTransactionParams)
 
     expect(rawTransactionResponse.status).toBe(HttpStatus.BAD_REQUEST)
-    expect(rawTransactionResponse.body.message.includes(`Provided address "${badContractAddress}" is invalid`)).toBeTruthy()
+    expect(rawTransactionResponse.body.message.includes(`"${badContractAddress}"`)).toBeTruthy()
   })
 
   it('Rejects 1 raw transaction request with bad from address', async () => {
@@ -430,7 +430,7 @@ describe('Transactions API Integration', () => {
     const rawTransactionResponse = await request(app).get(`/transactions/raw`).query(rawTransactionParams)
 
     expect(rawTransactionResponse.status).toBe(HttpStatus.BAD_REQUEST)
-    expect(rawTransactionResponse.body.message.includes(`Provided address "${badFromAddress.toLowerCase()}" is invalid`)).toBeTruthy()
+    expect(rawTransactionResponse.body.message.includes(`"${badFromAddress.toLowerCase()}"`)).toBeTruthy()
   })
 
   it('Rejects 1 transfer signed with the wrong key', async () => {

--- a/__tests__/integration/transactions.test.ts
+++ b/__tests__/integration/transactions.test.ts
@@ -529,21 +529,19 @@ describe('Transactions API Integration', () => {
     const expectedAddress = {
       "transactionCount": txCount,
       "balances": {
-        "private": [
-          {
-            "symbol": TOKEN.symbol,
-            "amount": (privateChain.initialLoyaltyTokenAmount - txCount).toString(), // assuming all value 1
-            "contractAddress": privateChain.loyaltyTokenContractAddress
-          }
-        ],
-        "public": [
-          {
-            "symbol": "QBX",
+        "private": {
+        },
+        "public": {
+          "QBX": {
             "balance": "0",
             "contractAddress": Config.getQBXAddress()
           }
-        ]
+        }
       }
+    }
+    expectedAddress.balances.private[TOKEN.symbol] = {
+      "balance": (privateChain.initialLoyaltyTokenAmount - txCount).toString(), // assuming all value 1
+      "contractAddress": privateChain.loyaltyTokenContractAddress
     }
 
     const r = await request(app).get(`/addresses/${ACCOUNTS[0].address}?public=true`)

--- a/__tests__/integration/transactions.test.ts
+++ b/__tests__/integration/transactions.test.ts
@@ -532,7 +532,7 @@ describe('Transactions API Integration', () => {
         "private": [
           {
             "symbol": TOKEN.symbol,
-            "amount": privateChain.initialLoyaltyTokenAmount - txCount, // assuming all value 1
+            "amount": (privateChain.initialLoyaltyTokenAmount - txCount).toString(), // assuming all value 1
             "contractAddress": privateChain.loyaltyTokenContractAddress
           }
         ],
@@ -546,7 +546,7 @@ describe('Transactions API Integration', () => {
       }
     }
 
-    const r = await request(app).get(`/addresses/${ACCOUNTS[0].address}`)
+    const r = await request(app).get(`/addresses/${ACCOUNTS[0].address}?public=true`)
     expect(r.status).toBe(HttpStatus.OK)
     expect(r.body).toEqual(expectedAddress)
   })

--- a/app.ts
+++ b/app.ts
@@ -17,6 +17,7 @@ import transactionsRouter from './src/transactions/router'
 import tokensRouter from './src/tokens/router'
 import usersRouter from './src/users/router'
 import pricesRouter from './src/prices/router'
+import addressesRouter from './src/addresses/router'
 
 import log from './src/logging'
 
@@ -48,6 +49,7 @@ app.use('/transactions', transactionsRouter)
 app.use('/tokens', tokensRouter)
 app.use('/users', usersRouter)
 app.use('/prices', pricesRouter)
+app.use('/addresses', addressesRouter)
 app.use('/', swaggerUi.serve, swaggerUi.setup(swaggerSpec))
 
 app.use((req, res, next) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@qiibee/qb-api",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -13349,7 +13349,7 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "qb-db-migrations": {
-      "version": "git+ssh://git@github.com/qiibee/qb-db-migrations.git#a0d477cfc4102c0fe7947cf303c3651f28e87fd3",
+      "version": "git+ssh://git@github.com/qiibee/qb-db-migrations.git#8c777bc5669aead2593936532b620695001d9a8a",
       "requires": {
         "jest": "23.5.0",
         "sequelize": "4.38.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "joi": "^13.7.0",
     "morgan": "^1.9.0",
     "mysql2": "^1.6.1",
-    "qb-db-migrations": "git+ssh@github.com:qiibee/qb-db-migrations.git#v0.5.0",
+    "qb-db-migrations": "git+ssh@github.com:qiibee/qb-db-migrations.git#v1.0.0",
     "sequelize": "^4.38.0",
     "swagger": "^0.7.5",
     "swagger-jsdoc": "^1.9.7",

--- a/src/addresses/controller.ts
+++ b/src/addresses/controller.ts
@@ -1,0 +1,61 @@
+import validation from '../validation'
+import * as Joi from 'joi'
+import database from '../database'
+import User from '../users/controller'
+import Config from '../config'
+import log from "../logging";
+import * as HttpStatus from 'http-status-codes'
+
+const web3 = Config.getPrivateWeb3()
+
+const getAddressSchema = Joi.object().keys({
+  params: Joi.object().keys({
+    address: validation.ethereumAddress().required()
+  })
+})
+async function getAddress(req, res) {
+  req = validation.validateRequestInput(req, getAddressSchema)
+  const address = req.params.address
+
+  let transactionCount = null
+  const tokenBalances = []
+  let qbxBalance = null
+  try {
+    transactionCount = await web3.eth.getTransactionCount(address.toLowerCase())
+    const tokens = await database.getTokens()
+    for (const token of tokens) {
+      let balance = await User.getBalance(address, token.contractAddress)
+
+      tokenBalances.push({
+        symbol: token.symbol,
+        amount: balance,
+        contractAddress: token.contractAddress
+      })
+    }
+
+    qbxBalance = await User.getQBXToken(address)
+  } catch (e) {
+    if (validation.isInvalidWeb3AddressMessage(e.message, address.toLowerCase())) {
+      log.error(e.message)
+      res.status(HttpStatus.BAD_REQUEST).json({ message: e.message })
+    } else {
+      throw e
+    }
+  }
+
+  res.json({
+    transactionCount: transactionCount,
+    balances: {
+      private: tokenBalances,
+      public: [{
+        symbol: qbxBalance.symbol,
+        balance: qbxBalance.balance,
+        contractAddress: qbxBalance.contractAddress
+      }]
+    }
+  })
+}
+
+export default {
+  getAddress
+}

--- a/src/addresses/controller.ts
+++ b/src/addresses/controller.ts
@@ -21,7 +21,7 @@ async function getAddress(req, res) {
   const address = req.params.address
 
   let transactionCount = null
-  const tokenBalances = []
+  const tokenBalances = {}
   let qbxBalance = null
   try {
     transactionCount = await web3.eth.getTransactionCount(address.toLowerCase())
@@ -29,11 +29,10 @@ async function getAddress(req, res) {
     for (const token of tokens) {
       let balance = await User.getBalance(address, token.contractAddress)
 
-      tokenBalances.push({
-        symbol: token.symbol,
-        amount: balance,
+      tokenBalances[token.symbol] = {
+        balance: balance,
         contractAddress: token.contractAddress
-      })
+      }
     }
 
     if (req.query.public) {
@@ -57,12 +56,13 @@ async function getAddress(req, res) {
   }
 
   if (req.query.public) {
-    response.balances.public = [{
-      symbol: qbxBalance.symbol,
-      balance: qbxBalance.balance,
-      contractAddress: qbxBalance.contractAddress
-    }]
+    response.balances.public = {}
+    response.balances.public[qbxBalance.symbol] = {
+        balance: qbxBalance.balance,
+        contractAddress: qbxBalance.contractAddress
+      }
   }
+
   res.json(response)
 }
 

--- a/src/addresses/router.ts
+++ b/src/addresses/router.ts
@@ -4,6 +4,34 @@ import Controller from '../addresses/controller'
 
 const router = express.Router()
 
+/**
+ * @swagger
+ * /addresses/address:
+ *   get:
+ *     tags:
+ *       - Addresses
+ *     description: Returns address information along with balances for each Loyalty Token.
+ *     produces:
+ *       - application/json
+ *     parameters:
+ *       - name: address
+ *         description: Users wallet address.
+ *         in: path
+ *         required: true
+ *         type: string
+ *       - name: public
+ *         description: Includes balance of the QBX public token.
+ *         in: query
+ *         required: false
+ *         type: boolean
+ *     responses:
+ *       200:
+ *          description: Returns successfully a List of all Loyalty Tokens in the qiibee chain
+ *       400:
+ *         description: Request failed due to wrong parameters, see error message
+ *       500:
+ *          description: Request failed, see error message
+ */
 router.get('/:address', LibAPI.wrap(Controller.getAddress))
 
 export default router

--- a/src/addresses/router.ts
+++ b/src/addresses/router.ts
@@ -1,0 +1,9 @@
+import * as express from 'express'
+import LibAPI from '../lib/utils'
+import Controller from '../addresses/controller'
+
+const router = express.Router()
+
+router.get('/:address', LibAPI.wrap(Controller.getAddress))
+
+export default router

--- a/src/database/index.ts
+++ b/src/database/index.ts
@@ -2,9 +2,9 @@ import * as sequelize from 'sequelize'
 import * as qbDB from 'qb-db-migrations'
 
 const Token = qbDB.models.token
-const Op = sequelize.Op;
+const Op = sequelize.Op
 
-const getTransactionHistory = async (address: string, limit: number, offset: number) => {
+async function getTransactionHistory(address: string, limit: number, offset: number) {
   const transactions = await qbDB.models.transaction.findAll({
     where: {
       $or: {
@@ -36,7 +36,7 @@ const getTransactionHistory = async (address: string, limit: number, offset: num
   return transactions
 }
 
-const getTransaction = async (hash: string) => {
+async function getTransaction(hash: string) {
   const transaction = await qbDB.models.transaction.find({
     where: {
       hash: hash,
@@ -58,7 +58,7 @@ interface PendingTransaction {
   Security NOTE: sequelize escapes the inputs if the '?' placeholder is used
  */
 
-const addPendingTransaction = async (transaction: PendingTransaction) => {
+async function addPendingTransaction(transaction: PendingTransaction) {
   const keys = Object.keys(transaction)
 
   /* insert if the primary key (transaction hash) is not present; do nothing otherwise.
@@ -73,11 +73,11 @@ const addPendingTransaction = async (transaction: PendingTransaction) => {
   return r
 }
 
-const getToken = async (contractAddress) => {
+async function getToken(contractAddress: string) {
   return await Token.find({ where: { contractAddress }, raw: true })
 }
 
-const getTokens = async () => {
+async function getTokens() {
   return await Token.findAll({
     where: {
       contractAddress: { [Op.ne]: null }

--- a/src/network/controller.ts
+++ b/src/network/controller.ts
@@ -2,7 +2,7 @@ import Config from '../config'
 
 const web3 = Config.getPrivateWeb3()
 
-const getInfo = async (req, res) => {
+async function getInfo(req, res) {
   const latestBlockNumber = await web3.eth.getBlockNumber(),
     latestBlock = await web3.eth.getBlock(latestBlockNumber)
 

--- a/src/prices/controller.ts
+++ b/src/prices/controller.ts
@@ -8,7 +8,7 @@ import validation from '../validation'
 const CRYPTO_COMPARE = 'https://min-api.cryptocompare.com/data'
 const QBX_ETH = 0.0001
 
-const tokenRate = async (tokenAddress) => {
+async function tokenRate(tokenAddress) {
   const TokenDB = TokenController.tokenDB()
   const token = await TokenDB.getToken(tokenAddress).call()
   const tokenRate = Number(token['2'])
@@ -29,7 +29,7 @@ const getPriceSchema = Joi.object().keys({
  * @param {object} res - respond object.
  * @return {json} The result.
  */
-const getPrice = async (req, res) => {
+async function getPrice(req, res) {
   req = validation.validateRequestInput(req, getPriceSchema)
   const {from, to} = req.query
 
@@ -71,7 +71,7 @@ const getHistorySchema = Joi.object().keys({
  * @param {object} res - respond object.
  * @return {json} The result.
  */
-const getHistory = async (req, res) => {
+async function getHistory(req, res) {
   req = validation.validateRequestInput(req, getHistorySchema)
   const { from, to, limit, aggregate, frequency} = req.query
 

--- a/src/tokens/controller.ts
+++ b/src/tokens/controller.ts
@@ -20,7 +20,7 @@ const loyaltyToken = (contractAddress) => new web3.eth.Contract(
   {}
 ).methods
 
-const getTokens = async (req, res) => {
+async function getTokens(req, res) {
   let publicTokens = undefined
   const tokens = await database.getTokens()
   for (const token of tokens) {
@@ -56,7 +56,7 @@ const getTokenSchema = Joi.object().keys({
  * @param {object} res - respond object.
  * @return {json} The result.
  */
-const getToken = async (req, res) => {
+async function getToken(req, res) {
   req = validation.validateRequestInput(req, getTokenSchema)
   const contractAddress = req.params.contract
   if (!contractAddress)

--- a/src/transactions/controller.ts
+++ b/src/transactions/controller.ts
@@ -14,7 +14,7 @@ import validation from '../validation'
 
 const web3 = Config.getPrivateWeb3()
 
-const getTx = async (txHash) => {
+async function getTx(txHash) {
   const endBlockNumber = await web3.eth.getBlock('latest'),
     transactionReceipt = await web3.eth.getTransactionReceipt(txHash.toLowerCase())
 
@@ -66,7 +66,7 @@ const getTransactionSchema = Joi.object().keys({
     hash: validation.ethereumHash().required(),
   })
 })
-const getTransaction = async (req, res) => {
+async function getTransaction(req, res) {
   req = validation.validateRequestInput(req, getTransactionSchema)
 
   const storedTx = await database.getTransaction(req.params.hash)
@@ -98,7 +98,7 @@ const getHistorySchema = Joi.object().keys({
     address: validation.ethereumAddress().required()
   })
 })
-const getHistory = async (req, res) => {
+async function getHistory(req, res) {
   req = validation.validateRequestInput(req, getHistorySchema)
   let {limit, offset} = req.query
 
@@ -117,7 +117,7 @@ const transferSchema = Joi.object().keys({
     data: Joi.string().required()
   })
 })
-const transfer = async (req, res) => {
+async function transfer(req, res) {
   req = validation.validateRequestInput(req, transferSchema)
 
   abiDecoder.addABI(Config.getTokenABI())
@@ -187,7 +187,7 @@ const buildRawTransactionSchema = Joi.object().keys({
     transferAmount: validation.bigPositiveIntAsString().required()
   })
 })
-const buildRawTransaction = async (req, res) => {
+async function buildRawTransaction(req, res) {
   req = validation.validateRequestInput(req, buildRawTransactionSchema)
   const { from, to, contractAddress, transferAmount } = req.query
 

--- a/src/users/controller.ts
+++ b/src/users/controller.ts
@@ -47,7 +47,7 @@ const getInfoSchema = Joi.object().keys({
     from: validation.ethereumAddress().required(),
   }
 })
-const getInfo = async function (req, res) {
+async function getInfo(req, res) {
   // TODO: include more info? Otherwise, just rename this route to /users/{from}/transactions.
   req = validation.validateRequestInput(req, getInfoSchema)
   const address = req.params.from

--- a/src/users/controller.ts
+++ b/src/users/controller.ts
@@ -9,7 +9,7 @@ import validation from '../validation'
 const web3 = Config.getPrivateWeb3()
 const web3Pub = Config.getPublicWeb3()
 
-const getBalance = async (from = null, contractAddress) => {
+async function getBalance(from: string = null, contractAddress: string): Promise<string> {
   const Token= TokenController.loyaltyToken(contractAddress.toLowerCase())
   let balance = '0'
   if (from) {
@@ -19,7 +19,7 @@ const getBalance = async (from = null, contractAddress) => {
   return balance
 }
 
-const getQBXToken = async (from = null) => {
+async function getQBXToken(from: string = null) {
   const QiibeeToken = new web3Pub.eth.Contract(Config.getTokenABI(), Config.getQBXAddress(), {}).methods
   const totalSupply = await QiibeeToken.totalSupply().call()
   let balance = 0
@@ -39,7 +39,6 @@ const getQBXToken = async (from = null) => {
       description: 'Loyalty on the blockchain.',
       website: 'https://www.qiibee.com',
       logoUrl: 'https://s3.eu-central-1.amazonaws.com/tokens.qiibee/qbx/logo.png'
-
     }
 }
 

--- a/src/validation/index.ts
+++ b/src/validation/index.ts
@@ -35,11 +35,11 @@ function validateRequestInput(req: express.Request, schema): express.Request {
 }
 
 function ethereumAddress()  {
-  return Joi.string().alphanum().length(42, 'utf8')
+  return Joi.string().length(42, 'utf8').regex(/^0(x|X)[a-fA-F0-9]{40}$/)
 }
 
 function ethereumHash()  {
-  return Joi.string().alphanum().length(66, 'utf8')
+  return Joi.string().length(66, 'utf8').regex(/^0(x|X)[a-fA-F0-9]{64}$/)
 }
 
 function bigPositiveIntAsString() {


### PR DESCRIPTION
TICKET
https://qiibee.atlassian.net/browse/PD-58

OTHER examples of /addresses endpoints

maybe we can refine our initial design, check them out before review

https://www.blockcypher.com/dev/ethereum/#address-api
https://developers.ripple.com/data-api.html#get-account


Notice how the ripple API has a separate balances sub object. which can make sense because we have plurality of balances, unlike the blockcypher API which is specific for ETH there.

i did something different from the original design where in now put instead of:

private: [

“LTS”: 10,

“SXC”: 20,

],

objects with 

```
{
        balance: balance,
        contractAddress: token.contractAddress
      }
```
thinking this design is more flexible because you can add more fields without breaking changes, as opposed to just having the integer. also added the contract address in there, we could just remove it though since it's not immediately necessary, but it acts as a unique ref though.