### PR TITLE
implement cached fetching of QBX/ETH prices value

### DIFF
--- a/__tests__/integration/prices.test.ts
+++ b/__tests__/integration/prices.test.ts
@@ -1,12 +1,9 @@
-import * as nock from 'nock'
 import axios from 'axios'
 import * as HttpStatus from 'http-status-codes'
 import * as request from 'supertest'
 import log from '../../src/logging'
 import APITesting from '../apiTesting'
 import TestPrivateChain from './testPrivateChain'
-import utils from '../../src/lib/utils'
-import qbxFeeCalculator from '../../src/lib/qbxFeeCalculator'
 import BigNumber from 'bignumber.js'
 
 const ETH_PRICE_USD = 500

--- a/__tests__/integration/prices.test.ts
+++ b/__tests__/integration/prices.test.ts
@@ -1,10 +1,10 @@
 import axios from 'axios'
+import BigNumber from 'bignumber.js'
 import * as HttpStatus from 'http-status-codes'
 import * as request from 'supertest'
 import log from '../../src/logging'
 import APITesting from '../apiTesting'
 import TestPrivateChain from './testPrivateChain'
-import BigNumber from 'bignumber.js'
 
 const ETH_PRICE_USD = 500
 const ETH_PRICE_EUR = 400
@@ -37,7 +37,6 @@ const TOKEN = {
   contractAddress: undefined,
   hidden: false
 }
-
 
 APITesting.setupTestConfiguration(INTEGRATION_TEST_CONFIGURATION)
 
@@ -113,7 +112,7 @@ describe('Prices API Integration', () => {
       .get(`/prices`)
       .query(pricesParams)
 
-    //expect(coinsuperScope.isDone()).toBeTruthy()
+    // expect(coinsuperScope.isDone()).toBeTruthy()
     expect(response.status).toBe(HttpStatus.OK)
     expect(response.body).toEqual({
       USD: ((ETH_PRICE_QBX * ETH_PRICE_USD) / TOKEN.rate).toFixed(4)

--- a/__tests__/integration/prices.test.ts
+++ b/__tests__/integration/prices.test.ts
@@ -10,6 +10,7 @@ const ETH_PRICE_USD = 500
 const ETH_PRICE_EUR = 400
 const ETH_PRICE_CHF = 480
 const ETH_PRICE_QBX = 0.0001
+const DECIMAL_COUNT = 10
 
 const ACCOUNTS = APITesting.ACCOUNTS
 const PRIVATE_WEB3_PORT = 8545
@@ -115,7 +116,7 @@ describe('Prices API Integration', () => {
     // expect(coinsuperScope.isDone()).toBeTruthy()
     expect(response.status).toBe(HttpStatus.OK)
     expect(response.body).toEqual({
-      USD: ((ETH_PRICE_QBX * ETH_PRICE_USD) / TOKEN.rate).toFixed(4)
+      USD: ((ETH_PRICE_QBX * ETH_PRICE_USD) / TOKEN.rate).toFixed(DECIMAL_COUNT)
     })
   })
 
@@ -142,9 +143,9 @@ describe('Prices API Integration', () => {
 
     expect(response.status).toBe(HttpStatus.OK)
     expect(response.body).toEqual({
-      USD: ((ETH_PRICE_QBX * ETH_PRICE_USD) / TOKEN.rate).toFixed(4),
-      CHF: ((ETH_PRICE_QBX * ETH_PRICE_CHF) / TOKEN.rate).toFixed(4),
-      EUR: ((ETH_PRICE_QBX * ETH_PRICE_EUR) / TOKEN.rate).toFixed(4)
+      USD: ((ETH_PRICE_QBX * ETH_PRICE_USD) / TOKEN.rate).toFixed(DECIMAL_COUNT),
+      CHF: ((ETH_PRICE_QBX * ETH_PRICE_CHF) / TOKEN.rate).toFixed(DECIMAL_COUNT),
+      EUR: ((ETH_PRICE_QBX * ETH_PRICE_EUR) / TOKEN.rate).toFixed(DECIMAL_COUNT)
     })
   })
 
@@ -165,7 +166,7 @@ describe('Prices API Integration', () => {
 
     expect(response.status).toBe(HttpStatus.OK)
     expect(response.body).toEqual({
-      USD: ((ETH_PRICE_QBX * ETH_PRICE_USD) / TOKEN.rate).toFixed(4)
+      USD: ((ETH_PRICE_QBX * ETH_PRICE_USD) / TOKEN.rate).toFixed(DECIMAL_COUNT)
     })
   })
 

--- a/__tests__/integration/transactions.test.ts
+++ b/__tests__/integration/transactions.test.ts
@@ -668,7 +668,7 @@ describe('Transactions API Integration', () => {
         data: {
           result: {
             bids: [{
-              limitPrice: qbxToETHExchangeRate.toString(),
+              limitPrice: qbxToETHExchangeRate.toFixed(),
               amount: '10000'
             }]
           }
@@ -719,7 +719,7 @@ describe('Transactions API Integration', () => {
         data: {
           result: {
             bids: [{
-              limitPrice: qbxToETHExchangeRate.toString(),
+              limitPrice: qbxToETHExchangeRate.toFixed(),
               amount: '10000'
             }]
           }
@@ -764,7 +764,7 @@ describe('Transactions API Integration', () => {
         data: {
           result: {
             bids: [{
-              limitPrice: qbxToETHExchangeRate.toString(),
+              limitPrice: qbxToETHExchangeRate.toFixed(),
               amount: '10000'
             }]
           }
@@ -866,7 +866,7 @@ describe('Transactions API Integration', () => {
         data: {
           result: {
             bids: [{
-              limitPrice: qbxToETHExchangeRate.toString(),
+              limitPrice: qbxToETHExchangeRate.toFixed(),
               amount: '10000'
             }]
           }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2145,7 +2145,7 @@
     },
     "d": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/d/-/d-1.0.0.tgz",
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "requires": {
         "es5-ext": "^0.10.9"
@@ -12673,7 +12673,7 @@
     },
     "next-tick": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw="
     },
     "nock": {
@@ -12737,6 +12737,15 @@
           "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
           "dev": true
         }
+      }
+    },
+    "node-cache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-4.2.0.tgz",
+      "integrity": "sha512-obRu6/f7S024ysheAjoYFEEBqqDWv4LOMNJEuO8vMeEw2AT4z+NCzO4hlc2lhI4vATzbCQv6kke9FVdx0RbCOw==",
+      "requires": {
+        "clone": "2.x",
+        "lodash": "4.x"
       }
     },
     "node-int64": {
@@ -14385,7 +14394,7 @@
           "dependencies": {
             "string-width": {
               "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "resolved": "http://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "requires": {
                 "code-point-at": "^1.0.0",
@@ -14405,7 +14414,7 @@
         },
         "load-json-file": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
           "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
           "requires": {
             "graceful-fs": "^4.1.2",
@@ -14432,7 +14441,7 @@
         },
         "pify": {
           "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
         },
         "read-pkg": {
@@ -14464,7 +14473,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "md5": "^2.2.1",
     "morgan": "^1.9.0",
     "mysql2": "^1.6.1",
+    "node-cache": "^4.2.0",
     "qb-db-migrations": "git+ssh@github.com:qiibee/qb-db-migrations.git#v1.4.0",
     "sequelize": "^4.38.0",
     "swagger": "^0.7.5",

--- a/src/lib/qbxFeeCalculator.ts
+++ b/src/lib/qbxFeeCalculator.ts
@@ -88,9 +88,15 @@ async function getQBXToETHExchangeRate(): Promise<BigNumber> {
   try {
     const response = await axios.post(postURL, requestData)
     const qbxToETH = new BigNumber(response.data.data.result.bids[0].limitPrice)
+    log.info(`Fetched QBX/ETH exchange rate from coinsuper: ${qbxToETH.toFixed()}`)
     return qbxToETH
   } catch (e) {
-    log.error(`Failed ${postURL} request: ${e} ${JSON.stringify(e.response.data)}`)
+    if (e.response) {
+      log.error(`Failed ${postURL} request: ${e.stack} ${JSON.stringify(e.response.data)}`)
+    } else {
+      log.error(`Failed ${postURL} request: ${e.stack}`)
+    }
+
     throw e
   }
 }
@@ -112,5 +118,6 @@ async function pullDataAndCalculateQBXTxValue(
 
 export default {
   pullDataAndCalculateQBXTxValue,
+  getQBXToETHExchangeRate,
   QBX_FEE_PERCENTAGE
 }

--- a/src/prices/controller.ts
+++ b/src/prices/controller.ts
@@ -65,7 +65,7 @@ async function getPrice(req, res) {
     Object.keys(data).forEach((key) => {
       const qbxFiat = qbxETHRate * data[key]
       const fiat = qbxFiat / rate
-      results[key] = fiat.toFixed(8)
+      results[key] = fiat.toFixed(10)
     })
   }
   return res.status(statusCode).json(results)

--- a/src/prices/controller.ts
+++ b/src/prices/controller.ts
@@ -65,7 +65,7 @@ async function getPrice(req, res) {
     Object.keys(data).forEach((key) => {
       const qbxFiat = qbxETHRate * data[key]
       const fiat = qbxFiat / rate
-      results[key] = fiat.toFixed(4)
+      results[key] = fiat.toFixed(8)
     })
   }
   return res.status(statusCode).json(results)

--- a/src/prices/controller.ts
+++ b/src/prices/controller.ts
@@ -1,10 +1,10 @@
 import axios from 'axios'
 import * as HttpStatus from 'http-status-codes'
 import * as Joi from 'joi'
-import database from '../database'
-import log from '../logging'
 import * as NodeCache from 'node-cache'
+import database from '../database'
 import qbxFeeCalculator from '../lib/qbxFeeCalculator'
+import log from '../logging'
 import validation from '../validation'
 
 const CRYPTO_COMPARE = 'https://min-api.cryptocompare.com/data'
@@ -13,8 +13,7 @@ const QBX_ETH_RATE_KEY = 'QBX_ETH_RATE'
 const cacheTime = 10  // 10 seconds cache
 const pricesCache = new NodeCache({ stdTTL: cacheTime, checkperiod: 0 })
 
-
-async function getCachedQBXETHRate() : Promise<number> {
+async function getCachedQBXETHRate(): Promise<number> {
   const cachedQbxEthRate = pricesCache.get(QBX_ETH_RATE_KEY)
   if (cachedQbxEthRate) {
     // @ts-ignore

--- a/src/prices/router.ts
+++ b/src/prices/router.ts
@@ -12,6 +12,7 @@ const router = express.Router()
  *       - Prices
  *     description: Returns the FIAT price of one unit of a given Loyalty Token. This endpoint uses
  *                  a third-party provider to get the ETH echange rate.
+ *                  The QBX/ETH Exchange rate is fetched from the Coinsuper exchange.
  *     produces:
  *       - application/json
  *     parameters:
@@ -44,6 +45,7 @@ router.get('/', LibAPI.wrap(Controller.getPrice))
  *       - Prices
  *     description: Returns the historical FIAT price values of one unit of a given Loyalty Token
  *                  for a desired currency. This endpoint uses a third-party provider to get the ETH exchange rate.
+ *                  The QBX/ETH Exchange rate is fetched from the Coinsuper exchange.
  *     produces:
  *       - application/json
  *     parameters:


### PR DESCRIPTION
TICKET
https://qiibee.atlassian.net/browse/PD-681

NOTE: we can actually make a single source for this rate to be shared between the exchanhe endpoint and this new requirement, but i applied a priniciple of least changes because this is a hotfix,  so we can work forward with this since it's time critical and apply that refactoring later.